### PR TITLE
Remove personal project references from Claude commands

### DIFF
--- a/.claude/commands/project-focus.md
+++ b/.claude/commands/project-focus.md
@@ -21,10 +21,12 @@ Activates deep focus mode for a specific project with full context loading and t
 ```
 
 Available projects:
-- `grupo-purdy` - Web scraping system for automotive market
-- `dojo-coding` - Educational platform and bootcamps
-- `indie-mind` - Content creation and marketing
-- `ai-agents` - Conversational AI development
+- `project-alpha` - Example project placeholder
+- `project-beta` - Example project placeholder
+- `project-gamma` - Example project placeholder
+- `project-delta` - Example project placeholder
+
+*Note: Replace these with your actual project names*
 
 ## Implementation:
 - Scans project folder in `01_projects/`


### PR DESCRIPTION
## Summary

Remove specific personal project references from the project-focus command and replace with generic placeholders to make the system template-ready.

## Changes Made

- **`.claude/commands/project-focus.md`**: Replaced specific project names (`grupo-purdy`, `dojo-coding`, `indie-mind`, `ai-agents`) with generic placeholders (`project-alpha`, `project-beta`, `project-gamma`, `project-delta`)
- Added note for users to replace placeholders with their actual project names

## Benefits

- Makes the second brain system usable as a clean template
- Removes personal project references that aren't relevant to other users
- Provides clear guidance on customization

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>